### PR TITLE
Use Identifier qualifier from smallrye-common instead of Named

### DIFF
--- a/galleon-feature-pack/galleon-content/src/main/resources/modules/system/layers/base/org/wildfly/extension/vertx/main/module.xml
+++ b/galleon-feature-pack/galleon-content/src/main/resources/modules/system/layers/base/org/wildfly/extension/vertx/main/module.xml
@@ -35,6 +35,7 @@
         <module name="org.jboss.as.weld.common"/>
         <module name="org.jboss.jandex"/>
         <module name="io.vertx.core" />
+        <module name="io.smallrye.common.annotation" />
         <module name="io.smallrye.reactive.mutiny.vertx-core" />
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.io.vertx.vertx>4.5.9</version.io.vertx.vertx>
         <version.io.smallrye.smallrye-mutiny-vertx>3.13.0</version.io.smallrye.smallrye-mutiny-vertx>
+        <version.io.smallrye.smallrye-common>2.5.0</version.io.smallrye.smallrye-common>
 
         <module.name>org.wildfly.extension.vertx</module.name>
 
@@ -102,6 +103,11 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-core</artifactId>
                 <version>${version.io.vertx.vertx}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-annotation</artifactId>
+                <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-core</artifactId>
         </dependency>

--- a/subsystem/src/main/java/org/wildfly/extension/vertx/VertxConstants.java
+++ b/subsystem/src/main/java/org/wildfly/extension/vertx/VertxConstants.java
@@ -27,7 +27,7 @@ public interface VertxConstants {
 
     String[] TIME_UNITS = Arrays.stream(TimeUnit.values()).map(Enum::toString).collect(Collectors.toList()).toArray(new String[0]);
 
-    String CDI_NAMED_QUALIFIER = "vertx";
+    String CDI_QUALIFIER = "vertx";
     String VERTX_SERVICE = "vertx";
     String ELEMENT_VERTX = "vertx";
 

--- a/testsuite/shared/src/main/java/org/wildfly/extension/vertx/test/shared/StreamUtils.java
+++ b/testsuite/shared/src/main/java/org/wildfly/extension/vertx/test/shared/StreamUtils.java
@@ -114,7 +114,7 @@ public class StreamUtils {
         try (StringReader sr = new StringReader(data)) {
             props.load(sr);
         } catch (IOException ioe) {
-            ;// ignore
+            // ignore
         }
         return props;
     }

--- a/testsuite/shared/src/main/java/org/wildfly/extension/vertx/test/shared/servlet/AsyncServlet.java
+++ b/testsuite/shared/src/main/java/org/wildfly/extension/vertx/test/shared/servlet/AsyncServlet.java
@@ -56,7 +56,7 @@ public class AsyncServlet extends HttpServlet {
                 consumer.unregister().toCompletionStage().toCompletableFuture().get();
                 consumer = null;
             } catch (Exception e) {
-                ; //ignore
+                //ignore
             }
         }
     }


### PR DESCRIPTION
After discussion with smallrye team on the CDI qualifier, the `@io.smallrye.common.annotation.Identifier` is used instead of `jakarta.enterprise.inject.literal.NamedLiteral`, more information can be found at: https://github.com/smallrye/smallrye-reactive-messaging/pull/2772