### PR TITLE
[Issue-40] Adds missing attributes

### DIFF
--- a/subsystem/src/main/java/org/wildfly/extension/vertx/AddressResolverResourceDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/extension/vertx/AddressResolverResourceDefinition.java
@@ -122,6 +122,11 @@ class AddressResolverResourceDefinition extends SimpleResourceDefinition impleme
     .setAllowExpression(true)
     .build();
 
+  public static final SimpleAttributeDefinition ATTR_HOSTS_REFRESH_PERIOD = new SimpleAttributeDefinitionBuilder(VertxConstants.ATTR_HOSTS_REFRESH_PERIOD, ModelType.INT)
+          .setRequired(false)
+          .setAllowExpression(true)
+          .build();
+
   private static final List<AttributeDefinition> VERTX_ADDRESS_RESOLVER_OPTIONS_ATTRS = new ArrayList<>();
   static {
     VERTX_ADDRESS_RESOLVER_OPTIONS_ATTRS.add(ATTR_HOSTS_PATH);
@@ -138,6 +143,7 @@ class AddressResolverResourceDefinition extends SimpleResourceDefinition impleme
     VERTX_ADDRESS_RESOLVER_OPTIONS_ATTRS.add(ATTR_N_DOTS);
     VERTX_ADDRESS_RESOLVER_OPTIONS_ATTRS.add(ATTR_ROTATE_SERVERS);
     VERTX_ADDRESS_RESOLVER_OPTIONS_ATTRS.add(ATTR_ROUND_ROBIN_INET_ADDRESS);
+    VERTX_ADDRESS_RESOLVER_OPTIONS_ATTRS.add(ATTR_HOSTS_REFRESH_PERIOD);
   }
 
   static List<AttributeDefinition> getVertxAddressResolverOptionsAttrs() {
@@ -255,6 +261,9 @@ class AddressResolverResourceDefinition extends SimpleResourceDefinition impleme
       }
       if (operation.hasDefined(VertxConstants.ATTR_ROUND_ROBIN_INET_ADDRESS)) {
         addressResolverOptions.setRoundRobinInetAddress(ATTR_ROUND_ROBIN_INET_ADDRESS.validateOperation(operation).asBoolean());
+      }
+      if (operation.hasDefined(VertxConstants.ATTR_HOSTS_REFRESH_PERIOD)) {
+        addressResolverOptions.setHostsRefreshPeriod(ATTR_HOSTS_REFRESH_PERIOD.validateOperation(operation).asInt());
       }
       return addressResolverOptions;
     }

--- a/subsystem/src/main/java/org/wildfly/extension/vertx/NamedVertxOptionsService.java
+++ b/subsystem/src/main/java/org/wildfly/extension/vertx/NamedVertxOptionsService.java
@@ -4,8 +4,12 @@
  */
 package org.wildfly.extension.vertx;
 
+import io.vertx.core.VertxOptions;
 import io.vertx.core.dns.AddressResolverOptions;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.dmr.ModelNode;
 import org.jboss.msc.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
@@ -14,8 +18,12 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 
+import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import static org.wildfly.extension.vertx.VertxConstants.ATTR_FS_FILE_CACHE_DIR;
+import static org.wildfly.extension.vertx.VertxConstants.ELEMENT_VERTX_OPTION_ADDRESS_RESOLVER;
 
 /**
  * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
@@ -25,38 +33,64 @@ public class NamedVertxOptionsService implements Service {
   private final NamedVertxOptions namedVertxOptions;
   private final Consumer<NamedVertxOptions> consumer;
   private final Supplier<AddressResolverOptions> addressResolverOptionsSupplier;
+  private final Supplier<ServerEnvironment> serverEnvironmentSupplier;
+  private final boolean defaultFileCacheDir;
 
-  NamedVertxOptionsService(NamedVertxOptions namedVertxOptions, Consumer<NamedVertxOptions> consumer) {
-    this(namedVertxOptions, null, consumer);
+  NamedVertxOptionsService(NamedVertxOptions namedVertxOptions,
+                           Consumer<NamedVertxOptions> consumer) {
+    this(namedVertxOptions, null, null, false, consumer);
   }
 
   NamedVertxOptionsService(NamedVertxOptions namedVertxOptions,
                            Supplier<AddressResolverOptions> addressResolverOptionsSupplier,
+                           Supplier<ServerEnvironment> serverEnvironmentSupplier,
+                           boolean defaultFileCacheDir,
                            Consumer<NamedVertxOptions> consumer) {
     this.namedVertxOptions = namedVertxOptions;
     this.addressResolverOptionsSupplier = addressResolverOptionsSupplier;
+    this.serverEnvironmentSupplier = serverEnvironmentSupplier;
+    this.defaultFileCacheDir = defaultFileCacheDir;
     this.consumer = consumer;
   }
 
-  static void installService(OperationContext context, NamedVertxOptions namedVertxOptions,
-                             String addressResolverOptionName) {
-    ServiceName vertxServiceName = VertxOptionFileResourceDefinition.VERTX_OPTIONS_CAPABILITY.getCapabilityServiceName(namedVertxOptions.getName());
+  /**
+   * Install NamedVertxOptionsService from '/subsystem=vertx/vertx-option=xx:add()'
+   * <p>
+   *     When 'file-cache-dir' is not configured, it defaults to '${jboss.server.temp.dir}/vertx-cache'
+   * </p>
+   * @param context the OperationContext to add a VertxOptions with a name
+   * @param operation the operation ModelNode to add a VertxOptions with a name
+   * @throws OperationFailedException when anything goes wrong
+   */
+  static void installVertxOptionsService(OperationContext context, ModelNode operation) throws OperationFailedException {
+    final String name = context.getCurrentAddressValue();
+    VertxOptions vertxOptions = VertxOptionsResourceDefinition.parseOptions(operation);
+    ServiceName vertxServiceName = VertxOptionFileResourceDefinition.VERTX_OPTIONS_CAPABILITY.getCapabilityServiceName(name);
     ServiceBuilder<?> vertxServiceBuilder = context.getCapabilityServiceTarget().addService();
-    Consumer<NamedVertxOptions> consumer = vertxServiceBuilder.provides(vertxServiceName);
     Supplier<AddressResolverOptions> addressResolverOptionsSupplier = null;
-    if (addressResolverOptionName != null) {
-      addressResolverOptionsSupplier = vertxServiceBuilder.requires(AddressResolverResourceDefinition.VERTX_OPTIONS_ADDRESS_RESOLVER_CAPABILITY.getCapabilityServiceName(addressResolverOptionName));
+    if (operation.hasDefined(ELEMENT_VERTX_OPTION_ADDRESS_RESOLVER)) {
+      String addressResolverOptionName = VertxOptionsAttributes.ATTR_VERTX_OPTION_ADDRESS_RESOLVER.validateOperation(operation).asString();
+      ServiceName addressResolverServiceName = AddressResolverResourceDefinition.VERTX_OPTIONS_ADDRESS_RESOLVER_CAPABILITY.getCapabilityServiceName(addressResolverOptionName);
+      addressResolverOptionsSupplier = vertxServiceBuilder.requires(addressResolverServiceName);
     }
-    vertxServiceBuilder.setInstance(new NamedVertxOptionsService(namedVertxOptions, addressResolverOptionsSupplier, consumer));
+    NamedVertxOptions namedVertxOptions = new NamedVertxOptions(name, vertxOptions);
+    ServiceName serverEnvServiceName = context.getCapabilityServiceName(ServerEnvironment.SERVICE_DESCRIPTOR);
+    Supplier<ServerEnvironment> environmentSupplier = vertxServiceBuilder.requires(serverEnvServiceName);
+    vertxServiceBuilder.setInstance(new NamedVertxOptionsService(namedVertxOptions, addressResolverOptionsSupplier,
+            environmentSupplier, !operation.hasDefined(ATTR_FS_FILE_CACHE_DIR), vertxServiceBuilder.provides(vertxServiceName)));
     vertxServiceBuilder
-      .setInitialMode(ServiceController.Mode.ACTIVE)
-      .install();
+            .setInitialMode(ServiceController.Mode.ACTIVE)
+            .install();
   }
 
   @Override
   public void start(StartContext startContext) throws StartException {
     if (this.addressResolverOptionsSupplier != null && this.addressResolverOptionsSupplier.get() != null) {
       this.namedVertxOptions.getVertxOptions().setAddressResolverOptions(this.addressResolverOptionsSupplier.get());
+    }
+    if (defaultFileCacheDir) {
+      String defaultCacheDir = serverEnvironmentSupplier.get().getServerTempDir().toPath().resolve(Path.of("vertx-cache")).normalize().toString();
+      this.namedVertxOptions.getVertxOptions().getFileSystemOptions().setFileCacheDir(defaultCacheDir);
     }
     this.consumer.accept(this.namedVertxOptions);
     VertxOptionsRegistry.getInstance().addVertxOptions(this.namedVertxOptions);

--- a/subsystem/src/main/java/org/wildfly/extension/vertx/VertxConstants.java
+++ b/subsystem/src/main/java/org/wildfly/extension/vertx/VertxConstants.java
@@ -44,10 +44,12 @@ public interface VertxConstants {
     // file system options
     String ATTR_FS_CLASS_PATH_RESOLVING_ENABLED = "classpath-resolving-enabled";
     String ATTR_FS_FILE_CACHE_ENABLED = "file-cache-enabled";
+    String ATTR_FS_FILE_CACHE_DIR = "file-cache-dir";
 
     // address resolver options
     String ATTR_HOSTS_PATH = "hosts-path";
     String ATTR_HOSTS_VALUE = "hosts-value";
+    String ATTR_HOSTS_REFRESH_PERIOD = "hosts-refresh-period";
     String ATTR_SERVERS = "servers";
     String ATTR_OPT_RES_ENABLED = "opt-resource-enabled";
     String ATTR_CACHE_MIN_TTL = "cache-min-time-to-live";

--- a/subsystem/src/main/java/org/wildfly/extension/vertx/VertxOptionsAttributes.java
+++ b/subsystem/src/main/java/org/wildfly/extension/vertx/VertxOptionsAttributes.java
@@ -117,6 +117,11 @@ public abstract class VertxOptionsAttributes implements VertxConstants {
     .setAllowExpression(true)
     .build();
 
+  public static final SimpleAttributeDefinition ATTR_FS_FILE_CACHE_DIR = new SimpleAttributeDefinitionBuilder(VertxConstants.ATTR_FS_FILE_CACHE_DIR, ModelType.STRING)
+          .setRequired(false)
+          .setAllowExpression(true)
+          .build();
+
   // address-resolver-option
   public static final SimpleAttributeDefinition ATTR_VERTX_OPTION_ADDRESS_RESOLVER = new SimpleAttributeDefinitionBuilder(VertxConstants.ELEMENT_VERTX_OPTION_ADDRESS_RESOLVER, ModelType.STRING)
     .setRequired(false)
@@ -141,6 +146,7 @@ public abstract class VertxOptionsAttributes implements VertxConstants {
     // file system options
     VERTX_OPTIONS_ATTRS.add(ATTR_FS_CLASS_PATH_RESOLVING_ENABLED);
     VERTX_OPTIONS_ATTRS.add(ATTR_FS_FILE_CACHE_ENABLED);
+    VERTX_OPTIONS_ATTRS.add(ATTR_FS_FILE_CACHE_DIR);
 
     // address-resolver-option
     VERTX_OPTIONS_ATTRS.add(ATTR_VERTX_OPTION_ADDRESS_RESOLVER);

--- a/subsystem/src/main/java/org/wildfly/extension/vertx/VertxOptionsResourceDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/extension/vertx/VertxOptionsResourceDefinition.java
@@ -25,6 +25,7 @@ import static org.wildfly.extension.vertx.VertxConstants.ATTR_BLOCKED_THREAD_CHE
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_BLOCKED_THREAD_CHECK_INTERVAL_UNIT;
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_EVENTLOOP_POOL_SIZE;
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_FS_CLASS_PATH_RESOLVING_ENABLED;
+import static org.wildfly.extension.vertx.VertxConstants.ATTR_FS_FILE_CACHE_DIR;
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_FS_FILE_CACHE_ENABLED;
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_INTERNAL_BLOCKING_POOL_SIZE;
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_MAX_EVENTLOOP_EXECUTE_TIME;
@@ -36,7 +37,6 @@ import static org.wildfly.extension.vertx.VertxConstants.ATTR_WARNING_EXECUTION_
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_WARNING_EXECUTION_TIME_UNIT;
 import static org.wildfly.extension.vertx.VertxConstants.ATTR_WORKER_POOL_SIZE;
 import static org.wildfly.extension.vertx.VertxConstants.ELEMENT_VERTX_OPTION;
-import static org.wildfly.extension.vertx.VertxConstants.ELEMENT_VERTX_OPTION_ADDRESS_RESOLVER;
 
 /**
  * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
@@ -79,66 +79,60 @@ class VertxOptionsResourceDefinition extends AbstractVertxOptionsResourceDefinit
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-      final String name = context.getCurrentAddressValue();
-      VertxOptions vertxOptions = parseOptions(operation);
-      NamedVertxOptions namedVertxOptions = new NamedVertxOptions(name, vertxOptions);
+      NamedVertxOptionsService.installVertxOptionsService(context, operation);
+    }
+  }
 
-      String addressResolverOptionName = null;
-      if (operation.hasDefined(ELEMENT_VERTX_OPTION_ADDRESS_RESOLVER)) {
-        addressResolverOptionName = VertxOptionsAttributes.ATTR_VERTX_OPTION_ADDRESS_RESOLVER.validateOperation(operation).asString();
-      }
-      NamedVertxOptionsService.installService(context, namedVertxOptions, addressResolverOptionName);
+  static VertxOptions parseOptions(ModelNode operation) throws OperationFailedException {
+    VertxOptions vertxOptions = new VertxOptions();
+    if (operation.hasDefined(ATTR_EVENTLOOP_POOL_SIZE)) {
+      vertxOptions.setEventLoopPoolSize(VertxOptionsAttributes.ATTR_EVENTLOOP_POOL_SIZE.validateOperation(operation).asInt());
+    }
+    if (operation.hasDefined(ATTR_WORKER_POOL_SIZE)) {
+      vertxOptions.setWorkerPoolSize(VertxOptionsAttributes.ATTR_WORKER_POOL_SIZE.validateOperation(operation).asInt());
+    }
+    if (operation.hasDefined(ATTR_INTERNAL_BLOCKING_POOL_SIZE)) {
+      vertxOptions.setInternalBlockingPoolSize(VertxOptionsAttributes.ATTR_INTERNAL_BLOCKING_POOL_SIZE.validateOperation(operation).asInt());
+    }
+    if (operation.hasDefined(ATTR_PREFER_NATIVE_TRANSPORT)) {
+      vertxOptions.setPreferNativeTransport(VertxOptionsAttributes.ATTR_PREFER_NATIVE_TRANSPORT.validateOperation(operation).asBoolean());
+    }
+    if (operation.hasDefined(ATTR_BLOCKED_THREAD_CHECK_INTERVAL)) {
+      vertxOptions.setBlockedThreadCheckInterval(VertxOptionsAttributes.ATTR_BLOCKED_THREAD_CHECK_INTERVAL.validateOperation(operation).asLong());
+    }
+    if (operation.hasDefined(ATTR_BLOCKED_THREAD_CHECK_INTERVAL_UNIT)) {
+      vertxOptions.setBlockedThreadCheckIntervalUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_BLOCKED_THREAD_CHECK_INTERVAL_UNIT.validateOperation(operation).asString()));
+    }
+    if (operation.hasDefined(ATTR_MAX_EVENTLOOP_EXECUTE_TIME)) {
+      vertxOptions.setMaxEventLoopExecuteTime(VertxOptionsAttributes.ATTR_MAX_EVENTLOOP_EXECUTE_TIME.validateOperation(operation).asLong());
+    }
+    if (operation.hasDefined(ATTR_MAX_EVENTLOOP_EXECUTE_TIME_UNIT)) {
+      vertxOptions.setMaxEventLoopExecuteTimeUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_MAX_EVENTLOOP_EXECUTE_TIME_UNIT.validateOperation(operation).asString()));
+    }
+    if (operation.hasDefined(ATTR_MAX_WORKER_EXECUTE_TIME)) {
+      vertxOptions.setMaxWorkerExecuteTime(VertxOptionsAttributes.ATTR_MAX_WORKER_EXECUTE_TIME.validateOperation(operation).asLong());
+    }
+    if (operation.hasDefined(ATTR_MAX_WORKER_EXECUTE_TIME_UNIT)) {
+      vertxOptions.setMaxWorkerExecuteTimeUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_MAX_WORKER_EXECUTE_TIME_UNIT.validateOperation(operation).asString()));
+    }
+    if (operation.hasDefined(ATTR_WARNING_EXECUTION_TIME)) {
+      vertxOptions.setWarningExceptionTime(VertxOptionsAttributes.ATTR_WARNING_EXECUTION_TIME.validateOperation(operation).asLong());
+    }
+    if (operation.hasDefined(ATTR_WARNING_EXECUTION_TIME_UNIT)) {
+      vertxOptions.setWarningExceptionTimeUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_WARNING_EXECUTION_TIME_UNIT.validateOperation(operation).asString()));
     }
 
-    VertxOptions parseOptions(ModelNode operation) throws OperationFailedException {
-      VertxOptions vertxOptions = new VertxOptions();
-      if (operation.hasDefined(ATTR_EVENTLOOP_POOL_SIZE)) {
-        vertxOptions.setEventLoopPoolSize(VertxOptionsAttributes.ATTR_EVENTLOOP_POOL_SIZE.validateOperation(operation).asInt());
-      }
-      if (operation.hasDefined(ATTR_WORKER_POOL_SIZE)) {
-        vertxOptions.setWorkerPoolSize(VertxOptionsAttributes.ATTR_WORKER_POOL_SIZE.validateOperation(operation).asInt());
-      }
-      if (operation.hasDefined(ATTR_INTERNAL_BLOCKING_POOL_SIZE)) {
-        vertxOptions.setInternalBlockingPoolSize(VertxOptionsAttributes.ATTR_INTERNAL_BLOCKING_POOL_SIZE.validateOperation(operation).asInt());
-      }
-      if (operation.hasDefined(ATTR_PREFER_NATIVE_TRANSPORT)) {
-        vertxOptions.setPreferNativeTransport(VertxOptionsAttributes.ATTR_PREFER_NATIVE_TRANSPORT.validateOperation(operation).asBoolean());
-      }
-      if (operation.hasDefined(ATTR_BLOCKED_THREAD_CHECK_INTERVAL)) {
-        vertxOptions.setBlockedThreadCheckInterval(VertxOptionsAttributes.ATTR_BLOCKED_THREAD_CHECK_INTERVAL.validateOperation(operation).asLong());
-      }
-      if (operation.hasDefined(ATTR_BLOCKED_THREAD_CHECK_INTERVAL_UNIT)) {
-        vertxOptions.setBlockedThreadCheckIntervalUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_BLOCKED_THREAD_CHECK_INTERVAL_UNIT.validateOperation(operation).asString()));
-      }
-      if (operation.hasDefined(ATTR_MAX_EVENTLOOP_EXECUTE_TIME)) {
-        vertxOptions.setMaxEventLoopExecuteTime(VertxOptionsAttributes.ATTR_MAX_EVENTLOOP_EXECUTE_TIME.validateOperation(operation).asLong());
-      }
-      if (operation.hasDefined(ATTR_MAX_EVENTLOOP_EXECUTE_TIME_UNIT)) {
-        vertxOptions.setMaxEventLoopExecuteTimeUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_MAX_EVENTLOOP_EXECUTE_TIME_UNIT.validateOperation(operation).asString()));
-      }
-      if (operation.hasDefined(ATTR_MAX_WORKER_EXECUTE_TIME)) {
-        vertxOptions.setMaxWorkerExecuteTime(VertxOptionsAttributes.ATTR_MAX_WORKER_EXECUTE_TIME.validateOperation(operation).asLong());
-      }
-      if (operation.hasDefined(ATTR_MAX_WORKER_EXECUTE_TIME_UNIT)) {
-        vertxOptions.setMaxWorkerExecuteTimeUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_MAX_WORKER_EXECUTE_TIME_UNIT.validateOperation(operation).asString()));
-      }
-      if (operation.hasDefined(ATTR_WARNING_EXECUTION_TIME)) {
-        vertxOptions.setWarningExceptionTime(VertxOptionsAttributes.ATTR_WARNING_EXECUTION_TIME.validateOperation(operation).asLong());
-      }
-      if (operation.hasDefined(ATTR_WARNING_EXECUTION_TIME_UNIT)) {
-        vertxOptions.setWarningExceptionTimeUnit(TimeUnit.valueOf(VertxOptionsAttributes.ATTR_WARNING_EXECUTION_TIME_UNIT.validateOperation(operation).asString()));
-      }
-
-      // file system options
-      if (operation.hasDefined(ATTR_FS_CLASS_PATH_RESOLVING_ENABLED)) {
-        vertxOptions.getFileSystemOptions().setClassPathResolvingEnabled(VertxOptionsAttributes.ATTR_FS_CLASS_PATH_RESOLVING_ENABLED.validateOperation(operation).asBoolean());
-      }
-      if (operation.hasDefined(ATTR_FS_FILE_CACHE_ENABLED)) {
-        vertxOptions.getFileSystemOptions().setFileCachingEnabled(VertxOptionsAttributes.ATTR_FS_FILE_CACHE_ENABLED.validateOperation(operation).asBoolean());
-      }
-      return vertxOptions;
+    // file system options
+    if (operation.hasDefined(ATTR_FS_CLASS_PATH_RESOLVING_ENABLED)) {
+      vertxOptions.getFileSystemOptions().setClassPathResolvingEnabled(VertxOptionsAttributes.ATTR_FS_CLASS_PATH_RESOLVING_ENABLED.validateOperation(operation).asBoolean());
     }
-
+    if (operation.hasDefined(ATTR_FS_FILE_CACHE_ENABLED)) {
+      vertxOptions.getFileSystemOptions().setFileCachingEnabled(VertxOptionsAttributes.ATTR_FS_FILE_CACHE_ENABLED.validateOperation(operation).asBoolean());
+    }
+    if (operation.hasDefined(ATTR_FS_FILE_CACHE_DIR)) {
+      vertxOptions.getFileSystemOptions().setFileCacheDir(VertxOptionsAttributes.ATTR_FS_FILE_CACHE_DIR.validateOperation(operation).asString());
+    }
+    return vertxOptions;
   }
 
   private static class ShowInfoHandler implements OperationStepHandler {

--- a/subsystem/src/main/resources/org/wildfly/extension/vertx/LocalDescriptions.properties
+++ b/subsystem/src/main/resources/org/wildfly/extension/vertx/LocalDescriptions.properties
@@ -31,8 +31,9 @@ vertx.vertx-option.max-worker-execute-time=The max worker execute time, defaults
 vertx.vertx-option.max-worker-execute-time-unit=The max worker execute time unit, defaults to NANOSECONDS
 vertx.vertx-option.warning-exception-time=The warning exception time, If a thread is blocked longer than this threshold, the warning log contains a stack trace, defaults to 5 seconds
 vertx.vertx-option.warning-exception-time-unit=The warning exception time, defaults to NANOSECONDS
-vertx.vertx-option.classpath-resolving-enabled=whether classpath resolving is enabled
-vertx.vertx-option.file-cache-enabled=whether file caching is enabled for class path resolving
+vertx.vertx-option.classpath-resolving-enabled=Whether classpath resolving is enabled
+vertx.vertx-option.file-cache-enabled=Whether file caching is enabled for class path resolving
+vertx.vertx-option.file-cache-dir=The file cache directory
 vertx.vertx-option.address-resolver-option=The address-resolver-option name used for the AddressResolverOptions
 vertx.vertx-option.show-info=Show VertxOptions information
 
@@ -54,3 +55,4 @@ vertx.address-resolver-option.search-domains=The lists of DNS search domains. Wh
 vertx.address-resolver-option.n-dots=The ndots value used when resolving using search domains, the default value is -1 which determines the value from the OS on Linux or uses the value 1.
 vertx.address-resolver-option.rotate-servers=The option to enable round-robin selection of the dns server to use. It spreads the query load among the servers and avoids all lookup to hit the first server of the list.
 vertx.address-resolver-option.round-robin-inet-address=The option to enable round-robin inet address selection of the ip address to use.
+vertx.address-resolver-option.hosts-refresh-period=The hosts configuration refresh period in millis

--- a/subsystem/src/main/resources/schema/wildfly-vertx_1_0_0.xsd
+++ b/subsystem/src/main/resources/schema/wildfly-vertx_1_0_0.xsd
@@ -63,7 +63,6 @@
         <xs:attribute name="worker-pool-size" type="xs:int" />
         <xs:attribute name="internal-blocking-pool-size" type="xs:int" />
         <xs:attribute name="prefer-native-transport" type="xs:boolean" />
-        <xs:attribute name="disable-tccl" type="xs:boolean" />
 
         <xs:attribute name="blocked-thread-check-interval" type="xs:long" />
         <xs:attribute name="blocked-thread-check-interval-unit" type="xs:string" />
@@ -76,6 +75,7 @@
 
         <xs:attribute name="classpath-resolving-enabled" type="xs:boolean" />
         <xs:attribute name="file-cache-enabled" type="xs:boolean" />
+        <xs:attribute name="file-cache-dir" type="xs:string" />
 
         <xs:attribute name="address-resolver-option" type="xs:string">
             <xs:annotation>
@@ -100,6 +100,7 @@
         <xs:attribute name="n-dots" type="xs:int" />
         <xs:attribute name="rotate-servers" type="xs:boolean" />
         <xs:attribute name="round-robin-inet-address" type="xs:boolean" />
+        <xs:attribute name="hosts-refresh-period" type="xs:int" />
     </xs:complexType>
 
 </xs:schema>

--- a/subsystem/src/test/resources/org/wildfly/extension/vertx/vertx-options-full.xml
+++ b/subsystem/src/test/resources/org/wildfly/extension/vertx/vertx-options-full.xml
@@ -6,7 +6,19 @@
 <subsystem xmlns="urn:wildfly:vertx:preview:1.0">
   <vertx option-name="vo" />
   <vertx-options>
-    <vertx-option name="vo" address-resolver-option="aro" />
-    <address-resolver-option name="aro" max-queries="20"/>
+    <vertx-option name="vo" address-resolver-option="aro" event-loop-pool-size="10"
+                  worker-pool-size="20" internal-blocking-pool-size="50" prefer-native-transport="false"
+                  blocked-thread-check-interval="2000" blocked-thread-check-interval-unit="MILLISECONDS"
+                  max-eventloop-execute-time="3000" max-eventloop-execute-time-unit="MILLISECONDS"
+                  max-worker-execute-time="5" max-worker-execute-time-unit="SECONDS"
+                  warning-exception-time="5" warning-exception-time-unit="SECONDS"
+                  classpath-resolving-enabled="true" file-cache-enabled="true" file-cache-dir="tmp"
+    />
+    <address-resolver-option name="aro" max-queries="20" hosts-path="/etc/hosts" hosts-value="127.0.0.1 localhost"
+                             servers="192.168.1.1,8.8.8.8" opt-resource-enabled="true"
+                             cache-min-time-to-live="30" cache-max-time-to-live="600" cache-negative-time-to-live="10"
+                             query-time-out="5000" rd-flag="true" search-domains="local,remote" n-dots="-1" rotate-servers="true"
+                             round-robin-inet-address="true" hosts-refresh-period="10000"
+    />
   </vertx-options>
 </subsystem>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/extension/vertx/test/basic/management/VertxOptionNoReloadRequiredTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/extension/vertx/test/basic/management/VertxOptionNoReloadRequiredTestCase.java
@@ -14,8 +14,11 @@ import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.addr
 import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.executeOperation;
 import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.isReloadRequired;
 import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.readVertxOptionOperation;
+import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.readVertxOptions;
+import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.serverTempDir;
 import static org.wildfly.extension.vertx.test.shared.ManagementClientUtils.vertxOptionOperation;
 
+import io.vertx.core.VertxOptions;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.management.util.ServerReload;
@@ -24,6 +27,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.vertx.test.shared.AbstractMgtTestBase;
+
+import java.nio.file.Path;
 
 /**
  * You can define many vertx options without having it referenced by the vertx instance, at that time, any changes to
@@ -48,6 +53,10 @@ public class VertxOptionNoReloadRequiredTestCase extends AbstractMgtTestBase {
     ModelNode result = response.get(RESULT);
     Assert.assertNotNull(result);
     Assert.assertFalse(isReloadRequired(managementClient));
+
+    // check the default file cache dir
+    VertxOptions vertxOptions = readVertxOptions(managementClient, vertxOptionName);
+    Assert.assertEquals(vertxOptions.getFileSystemOptions().getFileCacheDir(), Path.of(serverTempDir(managementClient), "vertx-cache").toString());
 
     // remove it won't lead to reload required
     executeOperation(managementClient, vertxOptionOperation(vertxOptionName, "remove"));

--- a/testsuite/integration/basic/src/test/java/org/wildfly/extension/vertx/test/basic/management/VertxOptionsManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/extension/vertx/test/basic/management/VertxOptionsManagementTestCase.java
@@ -52,6 +52,9 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         operation.get(ATTR_MAX_EVENTLOOP_EXECUTE_TIME).set(60);
         operation.get(ATTR_MAX_WORKER_EXECUTE_TIME).set(70);
         operation.get(ATTR_WARNING_EXECUTION_TIME).set(80);
+        operation.get(ATTR_FS_CLASS_PATH_RESOLVING_ENABLED).set(true);
+        operation.get(ATTR_FS_FILE_CACHE_ENABLED).set(true);
+        operation.get(ATTR_FS_FILE_CACHE_DIR).set("/tmp/.vertx-cache");
         executeOperation(managementClient, operation);
 
         ModelNode response = executeOperation(managementClient, readVertxOptionOperation(vertxOptionName));
@@ -65,6 +68,9 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         Assert.assertEquals(60L, result.get(ATTR_MAX_EVENTLOOP_EXECUTE_TIME).asLong());
         Assert.assertEquals(70L, result.get(ATTR_MAX_WORKER_EXECUTE_TIME).asLong());
         Assert.assertEquals(80L, result.get(ATTR_WARNING_EXECUTION_TIME).asLong());
+        Assert.assertTrue(result.get(ATTR_FS_CLASS_PATH_RESOLVING_ENABLED).asBoolean());
+        Assert.assertTrue(result.get(ATTR_FS_FILE_CACHE_ENABLED).asBoolean());
+        Assert.assertEquals("/tmp/.vertx-cache", result.get(ATTR_FS_FILE_CACHE_DIR).asString());
 
         VertxOptions vertxOptions = readVertxOptions(managementClient, vertxOptionName);
         Assert.assertEquals(10, vertxOptions.getEventLoopPoolSize());
@@ -76,6 +82,10 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         Assert.assertEquals(60L, vertxOptions.getMaxEventLoopExecuteTime());
         Assert.assertEquals(70L, vertxOptions.getMaxWorkerExecuteTime());
         Assert.assertEquals(80L, vertxOptions.getWarningExceptionTime());
+        Assert.assertNotNull(vertxOptions.getFileSystemOptions());
+        Assert.assertTrue(vertxOptions.getFileSystemOptions().isFileCachingEnabled());
+        Assert.assertTrue(vertxOptions.getFileSystemOptions().isClassPathResolvingEnabled());
+        Assert.assertEquals("/tmp/.vertx-cache", vertxOptions.getFileSystemOptions().getFileCacheDir());
 
         // clear resources
         executeOperation(managementClient, vertxOptionOperation(vertxOptionName, "remove"));
@@ -87,6 +97,7 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         final String addressResolverName = "aro";
         ModelNode operation = addressResolverOperation(addressResolverName, "add");
         operation.get(ATTR_HOSTS_PATH).set("local-path");
+        operation.get(ATTR_HOSTS_VALUE).set("127.0.0.1 localhost");
         operation.get(ATTR_SERVERS).add("localhost").add("127.0.0.1");
         operation.get(ATTR_OPT_RES_ENABLED).set(true);
         operation.get(ATTR_CACHE_MIN_TTL).set(1024);
@@ -99,6 +110,7 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         operation.get(ATTR_N_DOTS).set(8);
         operation.get(ATTR_ROTATE_SERVERS).set(true);
         operation.get(ATTR_ROUND_ROBIN_INET_ADDRESS).set(true);
+        operation.get(ATTR_HOSTS_REFRESH_PERIOD).set(100);
         executeOperation(managementClient, operation);
 
         ModelNode response = executeOperation(managementClient, addressResolverOperation(addressResolverName, "read-resource"));
@@ -123,6 +135,8 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         Assert.assertEquals(8, result.get(ATTR_N_DOTS).asInt());
         Assert.assertTrue(result.get(ATTR_ROTATE_SERVERS).asBoolean());
         Assert.assertTrue(result.get(ATTR_ROUND_ROBIN_INET_ADDRESS).asBoolean());
+        Assert.assertEquals(100, result.get(ATTR_HOSTS_REFRESH_PERIOD).asInt());
+        Assert.assertEquals("127.0.0.1 localhost", result.get(ATTR_HOSTS_VALUE).asString());
 
         final String optionName = "vo";
         ModelNode addVertxOption = vertxOptionOperation(optionName, "add");
@@ -146,6 +160,8 @@ public class VertxOptionsManagementTestCase implements VertxConstants {
         Assert.assertEquals(8, addressResolverOptions.getNdots());
         Assert.assertTrue(addressResolverOptions.isRotateServers());
         Assert.assertTrue(addressResolverOptions.isRoundRobinInetAddress());
+        Assert.assertEquals(100, addressResolverOptions.getHostsRefreshPeriod());
+        Assert.assertEquals("127.0.0.1 localhost", addressResolverOptions.getHostsValue().toString());
 
         // clear resources
         executeOperation(managementClient, vertxOptionOperation(optionName, "remove"));

--- a/testsuite/shared/src/main/java/org/wildfly/extension/vertx/test/shared/ManagementClientUtils.java
+++ b/testsuite/shared/src/main/java/org/wildfly/extension/vertx/test/shared/ManagementClientUtils.java
@@ -114,6 +114,17 @@ public final class ManagementClientUtils {
         return result.get("config-dir").asString();
     }
 
+    public static String serverTempDir(ManagementClient managementClient) throws IOException {
+        ModelNode address = new ModelNode();
+        address.add(CORE_SERVICE, "server-environment");
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        ModelNode result = executeOperation(managementClient, operation).get(RESULT);
+        return result.get("temp-dir").asString();
+    }
+
     public static boolean isReloadRequired(final ManagementClient managementClient) throws IOException {
         ModelNode operation = new ModelNode();
         operation.get(OP).set("read-attribute");


### PR DESCRIPTION
~* disableTCCL in VertxOptions~
~* useDaemonThread in VertxOptions~
* fileCacheDir in FileSystemOptions
* hostsRefreshPeriod in AddressResolverOptions

Fixes: #40 

Updates based on the discussions on https://github.com/wildfly/wildfly-proposals/pull/665:

* The `disableTCCL` and `useDaemonThread` should not be specified by end users.
* The default value of `fileCacheDir` should fall to the `${jboss.server.temp.dir}/vertx-cache`