### PR TITLE
Improve tests

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -16,7 +16,7 @@
     <version>1.0.3.Final-SNAPSHOT</version>
 
     <name>WildFly Vertx Extension - Distributions :: Server Distribution</name>
-    <description>This is the server distribution with the extension</description>
+    <description>This is the server distribution with this extension, the integration tests in this project depends on this server.</description>
 
     <packaging>pom</packaging>
 
@@ -39,11 +39,36 @@
     </dependencies>
 
     <build>
-        <finalName>${project.artifactId}-${project.version}</finalName>
+        <finalName>${server.name}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-channel-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/src/main/resources</directory>
+                                    <includes>
+                                        <include>wildfly-vertx-feature-pack-manifest.yaml</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -52,79 +77,66 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.artifactId}-${project.version}</install-dir>
-                            <record-state>false</record-state>
-
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>${project.build.directory}/${project.artifactId}-${project.version}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <offline-provisioning>true</offline-provisioning>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                                 <config-stability-level>preview</config-stability-level>
                                 <package-stability-level>preview</package-stability-level>
                                 <ignore-not-excluded-layers>true</ignore-not-excluded-layers>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-vertx-feature-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <inherit-configs>false</inherit-configs>
                                 </feature-pack>
                                 <feature-pack>
                                     <transitive>true</transitive>
                                     <groupId>org.wildfly</groupId>
                                     <artifactId>wildfly-ee-galleon-pack</artifactId>
                                     <version>${version.org.wildfly}</version>
-                                    <included-packages>
-                                        <name>docs.examples.configs</name>
-                                        <name>modules.all</name>
-                                    </included-packages>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                        </config>
-                                    </included-configs>
+                                    <inherit-configs>true</inherit-configs>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>org.wildfly</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${version.org.wildfly}</version>
-                                    <included-packages>
-                                        <name>docs.examples.configs</name>
-                                        <name>modules.all</name>
-                                    </included-packages>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-microprofile.xml</name>
-                                        </config>
-                                    </included-configs>
+                                    <inherit-configs>true</inherit-configs>
                                 </feature-pack>
                             </feature-packs>
-                            <configurations>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                    <layers>
-                                        <layer>jaxrs-server</layer>
-                                        <layer>vertx</layer>
-                                    </layers>
-                                </config>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone-microprofile.xml</name>
-                                    <layers>
-                                        <layer>jaxrs-server</layer>
-                                        <layer>microprofile-platform</layer>
-                                        <layer>vertx</layer>
-                                    </layers>
-                                </config>
-                            </configurations>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <url>file:///${project.build.directory}/wildfly-vertx-feature-pack-manifest.yaml</url>
+                                    </manifest>
+                                </channel>
+                            </channels>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>vertx-subsystem-init</id>
+                        <goals>
+                            <goal>execute-commands</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <offline>true</offline>
+                            <jboss-home>${project.build.directory}/${project.artifactId}-${project.version}</jboss-home>
+                            <commands>
+                                <command>embed-server --stability=preview</command>
+                                <command>/extension=org.wildfly.extension.vertx:add</command>
+                                <command>/subsystem=vertx:add</command>
+                                <command>/subsystem=vertx/vertx=vertx:add</command>
+                                <command>stop-embedded-server</command>
+                            </commands>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/build/src/main/resources/wildfly-vertx-feature-pack-manifest.yaml
+++ b/build/src/main/resources/wildfly-vertx-feature-pack-manifest.yaml
@@ -1,0 +1,15 @@
+schemaVersion: "1.0.0"
+name: "${project.artifactId}"
+id: "${project.groupId}:${project.artifactId}"
+description: "The WildFly vertx channel to upgrade components and dependencies"
+streams:
+  # wildfly-vertx-feature-pack dependencies
+  - groupId: "${project.groupId}"
+    artifactId: "wildfly-vertx-extension"
+    version: "${project.version}"
+  - groupId: "io.vertx"
+    artifactId: "vertx-core"
+    version: "${version.io.vertx.vertx}"
+  - groupId: "io.smallrye.reactive"
+    artifactId: "smallrye-mutiny-vertx-core"
+    version: "${version.io.smallrye.smallrye-mutiny-vertx}"

--- a/galleon-feature-pack/galleon-local/src/main/resources/packages/docs.licenses/content/docs/licenses/pm/wildfly/tasks.xml
+++ b/galleon-feature-pack/galleon-local/src/main/resources/packages/docs.licenses/content/docs/licenses/pm/wildfly/tasks.xml
@@ -7,7 +7,7 @@
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/wildfly-vertx-extension-licenses.xsl"/>
-    <transform stylesheet="docs/licenses/wildfly-mvc-krazo-licenses.xsl" src="docs/licenses/wildfly-vertx-extension-feature-pack-licenses.xml" output="docs/licenses/wildfly-vertx-extension-feature-pack-licenses.html" feature-pack-properties="true" phase="FINALIZING"/>
+    <transform stylesheet="docs/licenses/wildfly-vertx-extension-licenses.xsl" src="docs/licenses/wildfly-vertx-extension-feature-pack-licenses.xml" output="docs/licenses/wildfly-vertx-extension-feature-pack-licenses.html" feature-pack-properties="true" phase="FINALIZING"/>
     <delete path="docs/licenses/wildfly-vertx-extension-licenses.xsl"/>
     <line-endings phase="FINALIZING">
       <unix>

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/gaol/wildfly-vertx-extension.git</connection>
-        <developerConnection>scm:git:https://github.com/gaol/wildfly-vertx-extension.git</developerConnection>
-        <url>https://github.com/gaol/wildfly-vertx-extension/</url>
+        <connection>scm:git:https://github.com/wildfly-extras/wildfly-vertx-feature-pack.git</connection>
+        <developerConnection>scm:git:https://github.com/wildfly-extras/wildfly-vertx-feature-pack.git</developerConnection>
+        <url>https://github.com/wildfly-extras/wildfly-vertx-feature-pack</url>
       <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,25 +21,25 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- Require Java 11 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.release>11</maven.compiler.release>
+        <!-- Require Java 17 -->
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- WildFly versions -->
-        <version.org.wildfly>34.0.0.Final</version.org.wildfly>
-        <version.org.wildfly.core>26.0.1.Final</version.org.wildfly.core>
-        <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.io.vertx.vertx>4.5.9</version.io.vertx.vertx>
-        <version.io.smallrye.smallrye-mutiny-vertx>3.13.0</version.io.smallrye.smallrye-mutiny-vertx>
+        <version.org.wildfly>35.0.0.Final</version.org.wildfly>
+        <version.org.wildfly.core>27.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
+        <version.io.vertx.vertx>4.5.11</version.io.vertx.vertx>
+        <version.io.smallrye.smallrye-mutiny-vertx>3.15.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-common>2.5.0</version.io.smallrye.smallrye-common>
 
         <version.junit>4.13.1</version.junit>
 
         <!-- Plugin dependency versions -->
         <version.org.jboss.galleon>6.0.4.Final</version.org.jboss.galleon>
-        <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
         <version.org.apache.maven.plugins.maven-assembly-plugin>3.2.0</version.org.apache.maven.plugins.maven-assembly-plugin>
@@ -49,9 +49,6 @@
         <galleon.log.time>true</galleon.log.time>
         <galleon.offline>false</galleon.offline>
         <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
-
-        <server.output.dir.prefix>wildfly</server.output.dir.prefix>
-        <server.output.dir.version>${project.version}</server.output.dir.version>
 
         <!-- Release Information -->
         <full.dist.product.release.name>WildFly Vertx Extension</full.dist.product.release.name>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -21,7 +21,7 @@
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
-        <jboss.dist>${project.basedir}/target/wildfly</jboss.dist>
+        <jboss.dist>${project.build.directory}/wildfly</jboss.dist>
         <jboss.home>${jboss.dist}</jboss.home>
     </properties>
 
@@ -41,89 +41,36 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions combine.children="append">
                     <execution>
-                        <id>server-provisioning</id>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                        <phase>compile</phase>
+                        <id>ts.copy-wildfly</id>
+                        <inherited>true</inherited>
+                        <phase>generate-test-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
                         <configuration>
-                            <install-dir>${project.build.directory}/wildfly</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist />
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                                <ignore-not-excluded-layers>true</ignore-not-excluded-layers>
-                            </plugin-options>
-                            <feature-packs>
-                                <feature-pack>
-                                    <transitive>true</transitive>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
-                                    <version>${version.org.wildfly}</version>
-                                    <included-packages>
-                                        <name>docs.examples.configs</name>
-                                        <name>modules.all</name>
-                                    </included-packages>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-galleon-pack</artifactId>
-                                    <version>${version.org.wildfly}</version>
-                                    <included-packages>
-                                        <name>docs.examples.configs</name>
-                                        <name>modules.all</name>
-                                    </included-packages>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-vertx-feature-pack</artifactId>
-                                    <version>${project.version}</version>
-                                </feature-pack>
-                            </feature-packs>
-                            <configurations>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                    <layers>
-                                        <layer>jaxrs-server</layer>
-                                        <layer>jmx-remoting</layer>
-                                        <layer>ejb-lite</layer>
-                                        <layer>vertx</layer>
-                                    </layers>
-                                </config>
-                            </configurations>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <overwrite-provisioned-server>true</overwrite-provisioned-server>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>vertx-subsystem-init</id>
-                        <goals>
-                            <goal>execute-commands</goal>
-                        </goals>
-                        <phase>compile</phase>
-                        <configuration>
-                            <offline>true</offline>
-                            <jboss-home>${project.build.directory}/wildfly</jboss-home>
-                            <commands>
-                                <command>embed-server --stability=preview</command>
-                                <command>/subsystem=vertx/vertx=vertx:add</command>
-                                <command>stop-embedded-server</command>
-                            </commands>
+                            <outputDirectory>${jboss.dist}</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../../../build/target/wildfly-vertx-build-${project.version}</directory>
+                                    <excludes>
+                                        <exclude>bin/client/</exclude>
+                                        <exclude>bin/*.jar</exclude>
+                                        <exclude>bin/*.sh</exclude>
+                                        <exclude>bin/*.bat</exclude>
+                                        <exclude>bin/*.ps1</exclude>
+                                        <exclude>docs/licenses/</exclude>
+                                        <exclude>docs/schema/</exclude>
+                                        <exclude>docs/examples/configs/</exclude>
+                                        <exclude>welcome-content/*.png</exclude>
+                                        <exclude>standalone/data</exclude>
+                                        <exclude>standalone/log</exclude>
+                                        <exclude>standalone/tmp</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/extension/vertx/test/basic/VertxInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/extension/vertx/test/basic/VertxInjectionTestCase.java
@@ -15,7 +15,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.vertx.test.shared.ejb.EchoService;
@@ -32,7 +31,6 @@ import java.util.concurrent.TimeUnit;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("io.netty.netty-transport needs to be added as dependency to module: io.smallrye.reactive.mutiny.vertx-core")
 public class VertxInjectionTestCase {
     @ArquillianResource
     private URL url;


### PR DESCRIPTION
Fixes #49 

This PR tries to:
* Fix the scm url in pom
* Upgrade to WildFly 35.0.0.Final
* Update JDK requirement to 17 to aligh with WildFly 35
* Upgrade vertx core to 4.5.11, smallrye-mutiny-vertx to 3.15.0
* Introduce the manifest to provision the server with specified version of dependencies
* Do not provision the server again in the integration tests, copy from build distribution
* Enable the VertxInjectionTestCase